### PR TITLE
Fix includes being read twice and not using content provided by possibly overridden TryFindInclude

### DIFF
--- a/shaderc.net/Options.cs
+++ b/shaderc.net/Options.cs
@@ -95,8 +95,12 @@ namespace shaderc {
 
 			Options opts = optionsDic[userData.ToInt32 ()];
 			string content = "", incFile = "";
-
-			opts.TryFindInclude (requestingSource, requestedSource, (IncludeType)type, out incFile, out content);
+			
+			if (!opts.TryFindInclude (requestingSource, requestedSource, (IncludeType)type, out incFile, out content)) {
+				incFile = "";
+				if (content == null || content.Length == 0)
+					content = "Cannot find shader '" + requestedSource + "' included by '" + requestingSource + "'.";
+			}
 			
 			IncludeResult result = new IncludeResult (incFile, content, userData.ToInt32 ());
 			IntPtr irPtr = Marshal.AllocHGlobal (Marshal.SizeOf<IncludeResult> ());

--- a/shaderc.net/Options.cs
+++ b/shaderc.net/Options.cs
@@ -96,10 +96,8 @@ namespace shaderc {
 			Options opts = optionsDic[userData.ToInt32 ()];
 			string content = "", incFile = "";
 
-			if (opts.TryFindInclude (requestingSource, requestedSource, (IncludeType)type, out incFile, out content))
-				using (StreamReader sr = new StreamReader (incFile))
-					content = sr.ReadToEnd ();
-
+			opts.TryFindInclude (requestingSource, requestedSource, (IncludeType)type, out incFile, out content);
+			
 			IncludeResult result = new IncludeResult (incFile, content, userData.ToInt32 ());
 			IntPtr irPtr = Marshal.AllocHGlobal (Marshal.SizeOf<IncludeResult> ());
 			Marshal.StructureToPtr (result, irPtr, true);

--- a/shaderc.net/Options.cs
+++ b/shaderc.net/Options.cs
@@ -64,7 +64,7 @@ namespace shaderc {
 		/// <param name="includePath">include name to search for.</param>
 		/// <param name="incType">As in c, relative include or global</param>
 		/// <param name="incFile">the resolved name of the include, empty if resolution failed</param>
-		/// <param name="incContent">if resolution succeeded, contain the source code in plain text of the include</param>
+		/// <param name="incContent">if resolution succeeded, contains the source code in plain text of the include. Otherwise, contains an error message.</param>
 		protected virtual bool TryFindInclude (string sourcePath, string includePath, IncludeType incType, out string incFile, out string incContent) {
 			if (incType == IncludeType.Relative) {
 				incFile = Path.Combine (Path.GetDirectoryName (sourcePath), includePath);
@@ -86,7 +86,7 @@ namespace shaderc {
 			}
 
 			incFile = "";
-			incContent = "";
+			incContent = "Cannot find shader '" + includePath + "' included by '" + sourcePath + "'.";;
 			return false;
 		}
 
@@ -98,8 +98,6 @@ namespace shaderc {
 			
 			if (!opts.TryFindInclude (requestingSource, requestedSource, (IncludeType)type, out incFile, out content)) {
 				incFile = "";
-				if (content == null || content.Length == 0)
-					content = "Cannot find shader '" + requestedSource + "' included by '" + requestingSource + "'.";
 			}
 			
 			IncludeResult result = new IncludeResult (incFile, content, userData.ToInt32 ());


### PR DESCRIPTION
This library appears to read the content of included files twice, first in `TryFindInclude` then again in `HandlePFN_IncludeResolve`. This PR fixes that. This issue is particularly egregious because it forces anybody overriding `TryFindInclude` into returning a path to a real file  on the local computer, which may not be the case.